### PR TITLE
Allow getting any number of historical bars from the dydx adapter

### DIFF
--- a/nautilus_trader/adapters/dydx/data.py
+++ b/nautilus_trader/adapters/dydx/data.py
@@ -977,7 +977,6 @@ class DYDXDataClient(LiveMarketDataClient):
 
     async def _request_bars(self, request: RequestBars) -> None:
         max_bars = 1000
-        limit = request.limit if request.limit > 0 else max_bars
 
         if request.bar_type.is_internally_aggregated():
             self._log.error(
@@ -1038,11 +1037,12 @@ class DYDXDataClient(LiveMarketDataClient):
                 current_start = current_end
 
                 # Apply overall limit if specified
-                if limit > 0 and len(all_bars) >= limit:
-                    all_bars = all_bars[:limit]
+                if request.limit > 0 and len(all_bars) >= request.limit:
+                    all_bars = all_bars[: request.limit]
                     break
         else:
             # Single request
+            limit = request.limit if request.limit > 0 else max_bars
             all_bars = await self._fetch_candles(
                 symbol,
                 request.bar_type,

--- a/nautilus_trader/adapters/dydx/data.py
+++ b/nautilus_trader/adapters/dydx/data.py
@@ -977,7 +977,7 @@ class DYDXDataClient(LiveMarketDataClient):
 
     async def _request_bars(self, request: RequestBars) -> None:
         max_bars = 1000
-        limit = request.limit
+        limit = request.limit if request.limit > 0 else max_bars
 
         if request.bar_type.is_internally_aggregated():
             self._log.error(


### PR DESCRIPTION
## Summary

Removes the hardcoded limit of 100 historical bars (dydx API can do 1000) and automatically splits larger historical bar requests into multiple API calls so you can get the entire range.

Note: there might be other limits, such as rate limits, that could prevent getting a larger chunk of history. I tested only on reasonable ones so far.

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [X] New feature (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

**Ensure new or changed logic is covered by tests.**

I didn't modify the tests; let me know if I should add a case specific to a larger timespan that would trigger this new feature